### PR TITLE
remove SwiftLint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -55,15 +55,6 @@
       }
     },
     {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
-        "version" : "0.32.0"
-      }
-    },
-    {
       "identity" : "spectre",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kylef/Spectre.git",
@@ -97,33 +88,6 @@
       "state" : {
         "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
         "version" : "6.0.3"
-      }
-    },
-    {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint",
-      "state" : {
-        "revision" : "e8ef21fef61f12536964c4e3cf6d5a6e3ad81e49",
-        "version" : "0.46.5"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "6469881a3f30417c5bb02404ea4b69207f297592",
-        "version" : "6.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/swiftty/XcodeGen", branch: "feature/resources"),
-        .package(url: "https://github.com/realm/SwiftLint", from: "0.43.0"),
+//        .package(url: "https://github.com/realm/SwiftLint", from: "0.43.0"),
         .package(url: "https://github.com/swiftty/LicenseGen", from: "0.0.7")
     ]
 )


### PR DESCRIPTION
SourceKit in SwiftLint(0.4x) may fail when contained in package plugin process.
This may be resolved in SwiftLint >= 0.5x, but there is a dependency conflict with XcodeGen. 